### PR TITLE
Making it compile on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Thumbs.db
 *.pyc
+build/

--- a/Makefile
+++ b/Makefile
@@ -105,13 +105,13 @@ else
 	@cp "$<" "$@"
 endif
 
+define NL
+
+
+endef
+
 rename: $(ALL_FILES)
-	@$(subst ^, , \
-	  $(join \
-	    $(ALL_FILES:%=mv^%^), \
-	    $(ALL_COMPRESSED_FILES:%=%;^) \
-	  ) \
-	)
+	$(foreach pair, $(join $(ALL_FILES:%=%^), $(ALL_COMPRESSED_FILES)), @mv $(subst ^, ,$(pair))$(NL))
 
 $(ALL_COMPRESSED_FILES): rename
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ $(ALL_COMPRESSED_FILES): rename
 # Run make without -j if this happens.
 
 %.ttx: %.ttx.tmpl $(ADD_GLYPHS) $(ALL_COMPRESSED_FILES)
-	@python $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
+	@python2 $(ADD_GLYPHS) -f "$<" -o "$@" -d "$(COMPRESSED_DIR)" $(ADD_GLYPHS_FLAGS)
 
 %.ttf: %.ttx
 	@rm -f "$@"
@@ -134,8 +134,8 @@ $(ALL_COMPRESSED_FILES): rename
 
 $(EMOJI).ttf: $(EMOJI).tmpl.ttf $(EMOJI_BUILDER) $(PUA_ADDER) \
 	$(ALL_COMPRESSED_FILES) | check_vs_adder
-	@python $(EMOJI_BUILDER) -V $< "$@" "$(COMPRESSED_DIR)/emoji_u"
-	@python $(PUA_ADDER) "$@" "$@-with-pua"
+	@python2 $(EMOJI_BUILDER) -V $< "$@" "$(COMPRESSED_DIR)/emoji_u"
+	@python2 $(PUA_ADDER) "$@" "$@-with-pua"
 	@$(VS_ADDER) -vs 2640 2642 2695 --dstdir '.' -o "$@-with-pua-varsel" "$@-with-pua"
 	@mv "$@-with-pua-varsel" "$@"
 	@rm "$@-with-pua"


### PR DESCRIPTION
I was playing with your repo while looking at https://github.com/emojione/emojione/issues/524, these are the changes that I had to make in order to make it compile:

- The way your `rename` command works is it generates one large command to execute, the length of this command is so big that my shell did not want to accept it. The build was failing with `make: execvp: /bin/sh: Argument list too long`. The trick is to use new-lines, so that each rename command is executed separately.

- `python` defaults to python 3 by default, however something in fonttools or noto-tools cannot be compiled with python3. Most systems have aliases `python3` and `python2` in addition to `python`, here I'm using `python2` to force execution with that version of python.

Have a look if you want to merge everything or parts of it.