### PR TITLE
Rebrand EmojiOne to JoyPixels

### DIFF
--- a/JoyPixels.tmpl.ttx.tmpl
+++ b/JoyPixels.tmpl.ttx.tmpl
@@ -234,25 +234,25 @@
       Copyright 2019 JoyPixels Inc.
     </namerecord>
     <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne
+      JoyPixels
     </namerecord>
     <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
       Regular
     </namerecord>
     <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne
+      JoyPixels
     </namerecord>
     <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne
+      JoyPixels
     </namerecord>
     <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
       Version 4.5
     </namerecord>
     <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne
+      JoyPixels
     </namerecord>
     <namerecord nameID="7" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne is a trademark of JoyPixels Inc.
+      JoyPixels is a trademark of JoyPixels Inc.
     </namerecord>
     <namerecord nameID="8" platformID="3" platEncID="1" langID="0x409">
       JoyPixels Inc.
@@ -261,7 +261,7 @@
       JoyPixels Inc.
     </namerecord>
     <namerecord nameID="10" platformID="3" platEncID="1" langID="0x409">
-      EmojiOne for Android/Linux
+      JoyPixels for Android/Linux
     </namerecord>
     <namerecord nameID="11" platformID="3" platEncID="1" langID="0x409">
       https://www.joypixels.com/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-EMOJI = EmojiOne
+EMOJI = JoyPixels
 font: $(EMOJI).ttf
 
 # zopflipng is better (about 5-10%) but much slower.  it will be used if

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
-# EmojiOne for Android/Linux
+# JoyPixels for Android/Linux
 
-## Building EmojiOne
+## Building JoyPixels
 
-Building EmojiOne requires a few files from nototools.  Clone a copy from
+Building JoyPixels requires a few files from nototools. Clone a copy from
 https://github.com/googlei18n/nototools and either put it in your PYTHONPATH or
 use 'python setup.py develop' ('install' currently won't fully install all the
-data used by nototools).  You will also need fontTools, get it from
+data used by nototools). You will also need fontTools, get it from
 https://github.com/behdad/fonttools.git.
 
-Then run make.  EmojiOne is the default target.  It's suggested to use -j,
-especially if you are using zopflipng for compression.  Or you can use `NOCOMPRESSING=1`
-to skip compressing.  Intermediate products (compressed image files, for example)
+Then run make. JoyPixels is the default target. It's suggested to use -j,
+especially if you are using zopflipng for compression. Or you can use `NOCOMPRESSING=1`
+to skip compressing. Intermediate products (compressed image files, for example)
 will be put into a build subdirectory; the font will be at the top level.
 
 ## Prebuilt font file
-[EmojiOne.ttf](https://github.com/mxalbert1996/emojione-android/raw/master/fonts/EmojiOne.ttf)
 
-[EmojiOne_Watergun.ttf](https://github.com/mxalbert1996/emojione-android/raw/master/fonts/EmojiOne_Watergun.ttf) (Watergun alternative)
+[JoyPixels.ttf](https://github.com/mxalbert1996/emojione-android/raw/master/fonts/JoyPixels.ttf)
+
+[JoyPixels_Watergun.ttf](https://github.com/mxalbert1996/emojione-android/raw/master/fonts/JoyPixels_Watergun.ttf) (Watergun alternative)
 
 ## License
 
 Tools are under the [Apache license, version 2.0](./LICENSE).
 
-[EmojiOne image license](https://www.emojione.com/licenses/free)
+[JoyPixels image license](https://www.joypixels.com/licenses/free)


### PR DESCRIPTION
Have confirmed that the font officially is rebranded and it should be named "JoyPixels" just like the company name.